### PR TITLE
Feature/fix attack

### DIFF
--- a/AnimalFriends/Assets/Graphics/Wolf/animator.controller
+++ b/AnimalFriends/Assets/Graphics/Wolf/animator.controller
@@ -13,7 +13,7 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -88,9 +88,33 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.16005452
+  m_TransitionDuration: 0.15818602
   m_TransitionOffset: 0
   m_ExitTime: 0.28235036
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &1101267305877732916
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 6
+    m_ConditionEvent: state
+    m_EventTreshold: 3
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102870807021921908}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.5
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
@@ -136,10 +160,58 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 0.5
   m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &1101619278898549798
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 6
+    m_ConditionEvent: state
+    m_EventTreshold: 3
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102870807021921908}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0.03246758
+  m_ExitTime: 0.6331169
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &1101813389443473944
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 6
+    m_ConditionEvent: state
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102339452999723560}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.5
+  m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -160,9 +232,9 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.625
+  m_TransitionDuration: 0.011363655
+  m_TransitionOffset: 0.0151514895
+  m_ExitTime: 0.63636357
   m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
@@ -228,6 +300,7 @@ AnimatorState:
   m_Transitions:
   - {fileID: 1101866234320661452}
   - {fileID: 1101499806195963898}
+  - {fileID: 1101267305877732916}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -277,6 +350,7 @@ AnimatorState:
   m_Transitions:
   - {fileID: 1101259150015202784}
   - {fileID: 1101855905981710184}
+  - {fileID: 1101619278898549798}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -301,6 +375,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 1101887353881191192}
+  - {fileID: 1101813389443473944}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -367,7 +442,7 @@ AnimatorStateMachine:
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
-  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_AnyStatePosition: {x: 12, y: 96, z: 0}
   m_EntryPosition: {x: 48, y: 216, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}

--- a/AnimalFriends/Assets/Prefabs.meta
+++ b/AnimalFriends/Assets/Prefabs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9b9a6bb2cbe3b443c905cd6441224842
+guid: 6fb798bbd719b4252bd9476cf6bf22f0
 folderAsset: yes
 timeCreated: 1496417083
 licenseType: Free

--- a/AnimalFriends/Assets/Prefabs/claw1.prefab
+++ b/AnimalFriends/Assets/Prefabs/claw1.prefab
@@ -122,8 +122,8 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1524617279086226}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: -196.85599, y: 60.647934, z: 0}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1}
   m_Children:
   - {fileID: 4213636680338530}
   - {fileID: 4422875906689396}
@@ -154,7 +154,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 40, y: 100}
+  m_Size: {x: 80, y: 140}
   m_EdgeRadius: 0
 --- !u!114 &114623369196607380
 MonoBehaviour:

--- a/AnimalFriends/Assets/Prefabs/claw1.prefab
+++ b/AnimalFriends/Assets/Prefabs/claw1.prefab
@@ -197,8 +197,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 1479437069
+  m_SortingLayer: 2
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 0f759eee2ef0a4dae8feb8f8bdd6a656, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -237,8 +237,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 1479437069
+  m_SortingLayer: 2
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 0f759eee2ef0a4dae8feb8f8bdd6a656, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -277,8 +277,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 1479437069
+  m_SortingLayer: 2
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 0f759eee2ef0a4dae8feb8f8bdd6a656, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/AnimalFriends/Assets/Prefabs/claw2.prefab
+++ b/AnimalFriends/Assets/Prefabs/claw2.prefab
@@ -122,8 +122,8 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1312199358571262}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: -58.180664, y: 10.766144, z: 0}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1}
   m_Children:
   - {fileID: 4296751388983426}
   - {fileID: 4563138995076158}
@@ -154,7 +154,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 150, y: 40}
+  m_Size: {x: 190, y: 80}
   m_EdgeRadius: 0
 --- !u!114 &114120966682748856
 MonoBehaviour:

--- a/AnimalFriends/Assets/Prefabs/claw2.prefab
+++ b/AnimalFriends/Assets/Prefabs/claw2.prefab
@@ -197,8 +197,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 1479437069
+  m_SortingLayer: 2
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: e0def87512e8144a486d1e9230127857, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -237,8 +237,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 1479437069
+  m_SortingLayer: 2
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: e0def87512e8144a486d1e9230127857, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -277,8 +277,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 1479437069
+  m_SortingLayer: 2
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: e0def87512e8144a486d1e9230127857, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/AnimalFriends/Assets/Prefabs/claw3.prefab
+++ b/AnimalFriends/Assets/Prefabs/claw3.prefab
@@ -83,8 +83,8 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1266279668101222}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -257.9777, y: 77.89764, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 134.65642, y: 34.447906, z: 0}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1}
   m_Children:
   - {fileID: 4581035211465722}
   - {fileID: 4771713458037506}
@@ -154,7 +154,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 40, y: 100}
+  m_Size: {x: 80, y: 140}
   m_EdgeRadius: 0
 --- !u!114 &114206433552153328
 MonoBehaviour:
@@ -167,6 +167,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 443a55d782d84450f86c7ad89df8ef73, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  attackPower: 0
 --- !u!212 &212283740048772876
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/AnimalFriends/Assets/Prefabs/claw3.prefab
+++ b/AnimalFriends/Assets/Prefabs/claw3.prefab
@@ -197,8 +197,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 1479437069
+  m_SortingLayer: 2
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 0f759eee2ef0a4dae8feb8f8bdd6a656, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -237,8 +237,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 1479437069
+  m_SortingLayer: 2
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 0f759eee2ef0a4dae8feb8f8bdd6a656, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -277,8 +277,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 1479437069
+  m_SortingLayer: 2
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 0f759eee2ef0a4dae8feb8f8bdd6a656, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/AnimalFriends/Assets/Scenes/TestAnimationScene.unity
+++ b/AnimalFriends/Assets/Scenes/TestAnimationScene.unity
@@ -532,6 +532,24 @@ Prefab:
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1950528246956738, guid: de7c7267e56c843ab95ba0d76769b505, type: 2}
+      propertyPath: m_Layer
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 1469425137891604, guid: de7c7267e56c843ab95ba0d76769b505, type: 2}
+      propertyPath: m_Layer
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 212051575717552254, guid: de7c7267e56c843ab95ba0d76769b505,
+        type: 2}
+      propertyPath: m_SortingLayerID
+      value: -1424425053
+      objectReference: {fileID: 0}
+    - target: {fileID: 212051575717552254, guid: de7c7267e56c843ab95ba0d76769b505,
+        type: 2}
+      propertyPath: m_SortingLayer
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: de7c7267e56c843ab95ba0d76769b505, type: 2}
   m_IsPrefabParent: 0

--- a/AnimalFriends/Assets/Scripts/PhysicalAttackController.cs
+++ b/AnimalFriends/Assets/Scripts/PhysicalAttackController.cs
@@ -26,7 +26,7 @@ public class PhysicalAttackController : MonoBehaviour
         Vector2 scale = transform.localScale;
         if (!isRight)
         {
-            scale.x = -1.0f;
+            scale.x = Math.Abs(scale.x) * -1;
         }
         transform.localScale = scale;
     }

--- a/AnimalFriends/Assets/Scripts/PlayerController.cs
+++ b/AnimalFriends/Assets/Scripts/PlayerController.cs
@@ -11,7 +11,7 @@ public class PlayerController : MonoBehaviour
     private Rigidbody2D rb;
     private Animator animator;
     enum State { Idle = 0, Walk = 1, JumpUp = 2, JumpDown = 3, KnockBack = 4, };
-    enum AttackState { Idle = 0, Attack1 = 1, Attack2 = 2, Attack3 = 3, }
+    enum AttackState { Idle = 0, Attack1 = 1, Attack2 = 2, Attack3 = 3, SummerSalt = 4, }
     enum Direction { Right = 0, Left = 1, };
 
     State state;
@@ -57,6 +57,7 @@ public class PlayerController : MonoBehaviour
 
     Vector2 Move()
     {
+        SummarSolt();
         Vector2 scale = transform.localScale;
         Vector2 newVelocity;
         float velocityX = 0;
@@ -79,11 +80,14 @@ public class PlayerController : MonoBehaviour
             velocityX = 0;
         }
 
+        transform.localScale = scale;
+
         if (coolTime > 0)
         {
             if (state == State.Idle || state == State.Walk)
             {
-                velocityX = 0;
+                // 一旦攻撃中も移動できるようにした。 仕様次第
+                //velocityX = 0;
             }
             else if (state == State.KnockBack)
             {
@@ -94,12 +98,11 @@ public class PlayerController : MonoBehaviour
             return newVelocity;
         }
 
-        if (Input.GetKeyDown("up"))
+        if (Input.GetKeyDown("c"))
         {
             velocityY = jumpPower;
         }
 
-        transform.localScale = scale;
 
         newVelocity = new Vector2(velocityX, velocityY);
         rb.velocity = newVelocity;
@@ -139,17 +142,21 @@ public class PlayerController : MonoBehaviour
         Vector2 attackPosition = transform.position;
         Quaternion attackRotation = transform.rotation;
 
+        if (Input.GetKey("up"))
+        {
+            SummarSoltStart();
+        }
+
         if (direction == Direction.Right)
         {
-            attackPosition.x += 50;
+            attackPosition.x += 80;
             attackPosition.y -= 20;
         }
         else
         {
-            attackPosition.x -= 50;
+            attackPosition.x -= 80;
             attackPosition.y -= 20;
         }
-
 
         switch (attackState)
         {
@@ -177,6 +184,7 @@ public class PlayerController : MonoBehaviour
     {
         PhysicalAttackController physicalAttackController = Instantiate(PhysicalAttack, position, rotation);
         physicalAttackController.SetDirection(direction == Direction.Right);
+        physicalAttackController.transform.parent = transform;
     }
 
 
@@ -213,6 +221,23 @@ public class PlayerController : MonoBehaviour
                 break;
             default:
                 break;
+        }
+    }
+
+
+    // クソ実装
+    private void SummarSoltStart()
+    {
+        transform.Rotate(new Vector3(0, 0, 20));
+        float velocityX = rb.velocity.x; ;
+        float velocityY = jumpPower / 2;
+        rb.velocity = new Vector2(velocityX, velocityY);
+    }
+    private void SummarSolt()
+    {
+        if (transform.rotation != Quaternion.Euler(0, 0, 0))
+        {
+            transform.Rotate(new Vector3(0, 0, 20));
         }
     }
 }

--- a/AnimalFriends/Assets/Scripts/PlayerController.cs
+++ b/AnimalFriends/Assets/Scripts/PlayerController.cs
@@ -32,6 +32,7 @@ public class PlayerController : MonoBehaviour
     {
         rb = GetComponent<Rigidbody2D>();
         animator = GetComponent<Animator>();
+
         hpGauge = gameObject.transform.Find("hpGauge").gameObject;
         defaultGaugeWidth = hpGauge.transform.localScale.x;
 
@@ -60,20 +61,25 @@ public class PlayerController : MonoBehaviour
         SummarSolt();
         Vector2 scale = transform.localScale;
         Vector2 newVelocity;
-        float velocityX = 0;
+        float velocityX = rb.velocity.x;
         float velocityY = rb.velocity.y;
+
+        if (coolTime > 0 && state == State.KnockBack)
+        {
+            return rb.velocity;
+        }
 
         if (Input.GetKey("left"))
         {
             direction = Direction.Left;
             velocityX = -speed;
-            scale.x = -1;
+            scale.x = Math.Abs(scale.x) * -1;
         }
         else if (Input.GetKey("right"))
         {
             direction = Direction.Right;
             velocityX = speed;
-            scale.x = 1;
+            scale.x = Math.Abs(scale.x);
         }
         else
         {
@@ -82,27 +88,10 @@ public class PlayerController : MonoBehaviour
 
         transform.localScale = scale;
 
-        if (coolTime > 0)
-        {
-            if (state == State.Idle || state == State.Walk)
-            {
-                // 一旦攻撃中も移動できるようにした。 仕様次第
-                //velocityX = 0;
-            }
-            else if (state == State.KnockBack)
-            {
-                velocityX = rb.velocity.x;
-            }
-            newVelocity = new Vector2(velocityX, velocityY);
-            rb.velocity = newVelocity;
-            return newVelocity;
-        }
-
         if (Input.GetKeyDown("c"))
         {
             velocityY = jumpPower;
         }
-
 
         newVelocity = new Vector2(velocityX, velocityY);
         rb.velocity = newVelocity;
@@ -224,11 +213,9 @@ public class PlayerController : MonoBehaviour
         }
     }
 
-
-    // クソ実装
     private void SummarSoltStart()
     {
-        transform.Rotate(new Vector3(0, 0, 20));
+        transform.Rotate(new Vector3(0, 0, 24));
         float velocityX = rb.velocity.x; ;
         float velocityY = jumpPower / 2;
         rb.velocity = new Vector2(velocityX, velocityY);
@@ -237,7 +224,7 @@ public class PlayerController : MonoBehaviour
     {
         if (transform.rotation != Quaternion.Euler(0, 0, 0))
         {
-            transform.Rotate(new Vector3(0, 0, 20));
+            transform.Rotate(new Vector3(0, 0, 24));
         }
     }
 }

--- a/AnimalFriends/ProjectSettings/TagManager.asset
+++ b/AnimalFriends/ProjectSettings/TagManager.asset
@@ -26,10 +26,10 @@ TagManager:
   - 
   - block
   - 
+  - character
   - 
   - 
-  - 
-  - 
+  - effect
   - 
   - 
   - 
@@ -43,4 +43,10 @@ TagManager:
   m_SortingLayers:
   - name: Default
     uniqueID: 0
+    locked: 0
+  - name: character
+    uniqueID: 2870542243
+    locked: 0
+  - name: effect
+    uniqueID: 1479437069
     locked: 0


### PR DESCRIPTION
・攻撃範囲拡大
・攻撃がキャラクターの移動についてくるように子要素化
・ついでに地上でも移動中に攻撃できるように。立ち攻撃は立ち攻撃で分けたい場合は戻す
https://gyazo.com/b09de00b5017a6057fc168d6a226a4d2

・サマソ(クソ実装)
https://gyazo.com/53e439e12c8a1b7892ee07aab4a16a60

ついでの作業
・Order in Layer使ってエフェクトが前に来るようにした
・アニメーション調整して微妙に変わりきらないところを直した